### PR TITLE
feat: add Slack message schema and synthetic data generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,4 +217,7 @@ client_profiles.json
 # Chat preferences (AI settings + per-client industry)
 chat_preferences.json
 
+# Slack message data (synthetic / live, not tracked in git)
+slack_data.json
+
 .playwright-mcp/

--- a/app.py
+++ b/app.py
@@ -41,6 +41,11 @@ from chat_engine import (
     format_disambiguation,
     match_industry,
 )
+from slack_schema import (
+    get_messages_for_client,
+    get_messages_by_channel,
+    load_slack_data,
+)
 
 load_dotenv()
 
@@ -376,6 +381,9 @@ _defaults = {
     "conv_state": {},
     "results_visible": True,
     "results_collapsed": False,
+    # Slack state
+    "slack_messages": None,
+    "slack_query": None,
 }
 for key, default in _defaults.items():
     if key not in st.session_state:
@@ -572,6 +580,77 @@ def _render_risk_flags(risk_flags: list[dict]):
         )
 
 
+def _render_slack_panel(messages: list[dict], query: dict | None):
+    """Render Slack messages in the results panel."""
+    query = query or {}
+    client_name = query.get("client_name")
+    channel = query.get("channel")
+    sentiment = query.get("sentiment")
+
+    # Header with filter summary
+    parts = []
+    if client_name:
+        parts.append(f"**{client_name}**")
+    if channel:
+        parts.append(f"#{channel}")
+    if sentiment:
+        parts.append(f"{sentiment} sentiment")
+    title_suffix = " — " + ", ".join(parts) if parts else ""
+    st.subheader(f"Slack Messages{title_suffix}")
+    st.caption(f"{len(messages)} message(s) found")
+
+    sentiment_colors = {
+        "negative": ("#dc2626", "#fef2f2"),
+        "positive": ("#16a34a", "#f0fdf4"),
+        "neutral": ("#6b7280", "#f9fafb"),
+    }
+
+    for msg in messages:
+        s = msg.get("sentiment", "neutral")
+        text_color, bg_color = sentiment_colors.get(s, ("#6b7280", "#f9fafb"))
+        sev_label = s.upper()
+        ticket_ref = msg.get("ticket_reference")
+        ticket_html = (
+            f' <span style="font-size:0.75rem;color:#6b7280;">Ticket #{ticket_ref}</span>'
+            if ticket_ref
+            else ""
+        )
+        tags = msg.get("tags") or []
+        tag_html = "".join(
+            f'<span style="background:#e0e2ef;color:#242E65;font-size:0.7rem;'
+            f'padding:1px 6px;border-radius:4px;margin-left:4px;">{t}</span>'
+            for t in tags
+        )
+        ts = msg.get("timestamp", "")[:16].replace("T", " ")
+        sender = msg.get("sender_name", "")
+        sender_type = msg.get("sender_type", "")
+        sender_badge = (
+            '<span style="background:#242E65;color:white;font-size:0.65rem;'
+            'padding:1px 5px;border-radius:3px;margin-left:4px;">MSP</span>'
+            if sender_type == "msp_agent"
+            else ""
+        )
+        ch = msg.get("channel", "")
+        st.markdown(
+            f'<div style="background:{bg_color};border-left:4px solid {text_color};'
+            f'padding:0.6rem 0.85rem;margin-bottom:0.5rem;border-radius:8px;">'
+            f'<div style="display:flex;align-items:center;gap:0.4rem;margin-bottom:0.3rem;">'
+            f'<span style="background:{text_color};color:white;font-weight:600;'
+            f'font-size:0.65rem;padding:1px 6px;border-radius:3px;">{sev_label}</span>'
+            f'<span style="font-size:0.75rem;color:#6b7280;">#{ch}</span>'
+            f'<span style="font-size:0.75rem;color:#9ca3af;margin-left:auto;">{ts}</span>'
+            f"</div>"
+            f'<div style="color:#1a1a2e;font-size:0.9rem;margin-bottom:0.25rem;">'
+            f'{msg.get("message_text","")}'
+            f"</div>"
+            f'<div style="font-size:0.75rem;color:#6b7280;">'
+            f"{sender}{sender_badge}{ticket_html}{tag_html}"
+            f"</div>"
+            f"</div>",
+            unsafe_allow_html=True,
+        )
+
+
 def _render_results_dashboard():
     """Render the dashboard-style results view."""
     # Collapse toggle
@@ -587,6 +666,16 @@ def _render_results_dashboard():
         return
 
     st.markdown("---")
+
+    # Slack messages panel (may appear with or without a QBR)
+    if st.session_state.get("slack_messages") is not None:
+        _render_slack_panel(
+            st.session_state.slack_messages,
+            st.session_state.get("slack_query"),
+        )
+
+    if not st.session_state.qbr_bytes:
+        return
 
     # Download button
     st.download_button(
@@ -1214,6 +1303,78 @@ def _handle_chat_message(user_message: str):
             )
         return
 
+    if intent == Intent.SHOW_SLACK_MESSAGES:
+        client_name = params.get("client_name")
+        channel = params.get("channel")
+        sentiment = params.get("sentiment")
+
+        messages = []
+
+        if client_name:
+            # Try to match against HaloPSA clients first, then fall back to slack data names
+            if st.session_state.authenticated:
+                matches = resolve_client(client_name, st.session_state.clients)
+                if len(matches) == 1:
+                    messages = get_messages_for_client(matches[0]["id"])
+                    if not messages:
+                        # Fallback: match by client_name in slack data (synthetic/offline data)
+                        all_msgs = load_slack_data()
+                        messages = [
+                            m for m in all_msgs
+                            if client_name.lower() in m.client_name.lower()
+                        ]
+                elif len(matches) > 1:
+                    _add_message("assistant", format_disambiguation(matches))
+                    return
+                else:
+                    all_msgs = load_slack_data()
+                    messages = [
+                        m for m in all_msgs
+                        if client_name.lower() in m.client_name.lower()
+                    ]
+            else:
+                all_msgs = load_slack_data()
+                messages = [
+                    m for m in all_msgs
+                    if client_name.lower() in m.client_name.lower()
+                ]
+        elif channel:
+            messages = get_messages_by_channel(channel)
+        else:
+            messages = load_slack_data()
+
+        # Apply channel filter when client was also specified
+        if channel and client_name and messages:
+            messages = [m for m in messages if m.channel.lower() == channel.lower()]
+
+        # Apply sentiment filter
+        if sentiment and messages:
+            messages = [m for m in messages if m.sentiment == sentiment]
+
+        if not messages:
+            _add_message(
+                "assistant",
+                "No Slack messages found matching your query. "
+                "Run 'python populate_slack_data.py' to generate synthetic data.",
+            )
+            return
+
+        st.session_state.slack_messages = [m.to_dict() for m in messages]
+        st.session_state.slack_query = {
+            "client_name": client_name,
+            "channel": channel,
+            "sentiment": sentiment,
+        }
+        st.session_state.results_visible = True
+        st.session_state.results_collapsed = False
+
+        _add_message(
+            "assistant",
+            f"Found **{len(messages)}** Slack message(s). "
+            "See the Results panel for details.",
+        )
+        return
+
     if intent == Intent.SHOW_LAST_QBR:
         if st.session_state.qbr_bytes:
             st.session_state.results_collapsed = False
@@ -1464,7 +1625,10 @@ if not st.session_state.authenticated:
     )
 
 # ── Two-panel layout ──
-has_results = st.session_state.qbr_bytes is not None
+has_results = (
+    st.session_state.qbr_bytes is not None
+    or st.session_state.get("slack_messages") is not None
+)
 
 if has_results and st.session_state.results_visible:
     chat_col, results_col = st.columns([1, 1])

--- a/chat_engine.py
+++ b/chat_engine.py
@@ -19,6 +19,7 @@ class Intent(Enum):
     SET_CLIENT_PROFILE = "set_client_profile"
     SET_INDUSTRY = "set_industry"
     SHOW_LAST_QBR = "show_last_qbr"
+    SHOW_SLACK_MESSAGES = "show_slack_messages"
     HELP = "help"
     UNKNOWN = "unknown"
 
@@ -74,6 +75,14 @@ _INTENT_PATTERNS = [
         Intent.SHOW_LAST_QBR,
         re.compile(
             r"last\s+qbr|previous\s+qbr|recent\s+qbr",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        Intent.SHOW_SLACK_MESSAGES,
+        re.compile(
+            r"slack\s*messages?|show.*slack|slack.*for|slack.*channel|slack.*activity"
+            r"|slack.*incident|slack.*alert|slack.*support",
             re.IGNORECASE,
         ),
     ),
@@ -154,6 +163,37 @@ def _extract_params_regex(message: str, intent: Intent) -> dict:
         )
         if client_match:
             params["client_name"] = client_match.group(1).strip().strip("\"'")
+
+    elif intent == Intent.SHOW_SLACK_MESSAGES:
+        # Client name: "for <client>" — stop before "in", "channel", end
+        client_match = re.search(
+            r"(?:for|from)\s+(.+?)(?:\s+in\s+|\s+channel|\s*$|\s*\?)",
+            message,
+            re.IGNORECASE,
+        )
+        if client_match:
+            params["client_name"] = client_match.group(1).strip().strip("\"'")
+
+        # Channel: "#channel-name", "in channel-name", or "channel-name channel"
+        channel_match = re.search(
+            r"#([\w-]+)|in\s+([\w-]+)\s+channel|channel\s+#?([\w-]+)",
+            message,
+            re.IGNORECASE,
+        )
+        if channel_match:
+            params["channel"] = (
+                channel_match.group(1)
+                or channel_match.group(2)
+                or channel_match.group(3)
+            ).lower()
+
+        # Sentiment filter
+        if re.search(r"\bnegative\b", message, re.IGNORECASE):
+            params["sentiment"] = "negative"
+        elif re.search(r"\bpositive\b", message, re.IGNORECASE):
+            params["sentiment"] = "positive"
+        elif re.search(r"\bneutral\b", message, re.IGNORECASE):
+            params["sentiment"] = "neutral"
 
     return params
 
@@ -353,7 +393,7 @@ def parse_intent_llm(
 Given a user message and conversation context, extract the intent and parameters.
 
 Valid intents: generate_qbr, list_clients, show_health_score, set_ai_settings,
-set_client_profile, set_industry, show_last_qbr, help, unknown
+set_client_profile, set_industry, show_last_qbr, show_slack_messages, help, unknown
 
 Return ONLY valid JSON:
 {
@@ -368,6 +408,8 @@ Return ONLY valid JSON:
     "employee_count": "<integer or null>",
     "avg_hourly_rate": "<float or null>",
     "industry_name": "<string or null>",
+    "channel": "<string or null, Slack channel name without #>",
+    "sentiment": "<string or null, one of: positive, neutral, negative>",
     "is_skip": "<boolean, true if user wants to skip current question>"
   }
 }
@@ -450,6 +492,11 @@ def format_help_message() -> str:
 **Set industry**
 - "Acme is in healthcare"
 - "Set industry to Finance"
+
+**Slack messages**
+- "Show Slack messages for Acme Corp"
+- "Show incidents channel Slack messages for Ron's Iron works"
+- "Show negative Slack messages for Terry's Chocolates"
 
 **Other**
 - "Show last QBR" - download the most recently generated report"""

--- a/populate_slack_data.py
+++ b/populate_slack_data.py
@@ -1,0 +1,457 @@
+"""
+populate_slack_data.py
+Generates synthetic Slack message data tied to HaloPSA client accounts.
+
+Usage:
+    python populate_slack_data.py
+
+The script loads existing HaloPSA client IDs from client_profiles.json if
+available, or falls back to a built-in set of representative sample clients.
+It then creates realistic MSP-themed Slack messages across multiple channels
+and writes them to slack_data.json via the slack_schema persistence layer.
+
+Run again with --reset to clear existing data before generating fresh records.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from slack_schema import SlackMessage, delete_messages_for_client, load_slack_data, save_slack_data
+
+# ---------------------------------------------------------------------------
+# Seed for reproducibility (can be overridden via CLI)
+# ---------------------------------------------------------------------------
+DEFAULT_SEED = 42
+
+# ---------------------------------------------------------------------------
+# Realistic channels used in MSP/client shared Slack workspaces
+# ---------------------------------------------------------------------------
+CHANNELS = [
+    "general",
+    "support-alerts",
+    "incidents",
+    "maintenance-windows",
+    "announcements",
+    "security-updates",
+]
+
+# ---------------------------------------------------------------------------
+# MSP agent personas
+# ---------------------------------------------------------------------------
+MSP_AGENTS = [
+    {"sender_id": "U0MSP001", "sender_name": "Alex Rivera"},
+    {"sender_id": "U0MSP002", "sender_name": "Jordan Lee"},
+    {"sender_id": "U0MSP003", "sender_name": "Morgan Chen"},
+    {"sender_id": "U0MSP004", "sender_name": "Taylor Brooks"},
+]
+
+# ---------------------------------------------------------------------------
+# Per-client user templates (generated at runtime based on client name)
+# ---------------------------------------------------------------------------
+
+def _make_client_users(client_id: int, client_name: str) -> list[dict]:
+    slug = client_name.split()[0].upper()[:4]
+    return [
+        {"sender_id": f"U{slug}{client_id}01", "sender_name": f"{client_name} - IT Lead"},
+        {"sender_id": f"U{slug}{client_id}02", "sender_name": f"{client_name} - Office Manager"},
+        {"sender_id": f"U{slug}{client_id}03", "sender_name": f"{client_name} - Operations"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Message templates by channel and sentiment
+# ---------------------------------------------------------------------------
+
+_TEMPLATES: dict[str, list[dict]] = {
+    "general": [
+        {
+            "text": "Good morning team! Just a reminder that our quarterly review is scheduled for next week.",
+            "sentiment": "positive",
+            "tags": ["qbr", "reminder"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Hi everyone, we're updating our ticketing workflow. Please submit all requests through the portal.",
+            "sentiment": "neutral",
+            "tags": ["process", "tickets"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Thanks for the quick turnaround on our VPN issue last week!",
+            "sentiment": "positive",
+            "tags": ["feedback", "vpn"],
+            "sender_type": "client_user",
+        },
+        {
+            "text": "Can someone confirm the status of our server migration scheduled for this weekend?",
+            "sentiment": "neutral",
+            "tags": ["migration", "question"],
+            "sender_type": "client_user",
+        },
+    ],
+    "support-alerts": [
+        {
+            "text": "Ticket #{{TICKET}} opened: Users reporting slow network performance in the main office.",
+            "sentiment": "negative",
+            "tags": ["network", "performance", "slow"],
+            "sender_type": "client_user",
+        },
+        {
+            "text": "Ticket #{{TICKET}} resolved: VPN connectivity issue affecting remote workers has been fixed.",
+            "sentiment": "positive",
+            "tags": ["vpn", "resolved", "remote-work"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Ticket #{{TICKET}} opened: Printer on floor 2 is offline, affecting 15 users.",
+            "sentiment": "negative",
+            "tags": ["printer", "hardware"],
+            "sender_type": "client_user",
+        },
+        {
+            "text": "Ticket #{{TICKET}} updated: Email server restored. All services now operational.",
+            "sentiment": "positive",
+            "tags": ["email", "resolved"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Ticket #{{TICKET}} escalated: Critical — file server unreachable from all workstations.",
+            "sentiment": "negative",
+            "tags": ["critical", "file-server", "escalated"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Ticket #{{TICKET}} opened: Microsoft 365 license allocation needed for 3 new hires starting Monday.",
+            "sentiment": "neutral",
+            "tags": ["m365", "onboarding", "licenses"],
+            "sender_type": "client_user",
+        },
+    ],
+    "incidents": [
+        {
+            "text": "INCIDENT: Internet connectivity down across all sites. ISP notified. ETA: 2 hours.",
+            "sentiment": "negative",
+            "tags": ["incident", "internet", "outage", "critical"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "UPDATE: ISP reports fiber cut on main line. Failover to backup link now active. Degraded but operational.",
+            "sentiment": "neutral",
+            "tags": ["incident", "internet", "update", "failover"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "RESOLVED: Primary internet restored. All services back to normal. RCA report to follow.",
+            "sentiment": "positive",
+            "tags": ["incident", "resolved", "rca"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "INCIDENT: Ransomware detected on workstation WS-ACCT-03. Machine isolated. Investigation underway.",
+            "sentiment": "negative",
+            "tags": ["incident", "security", "ransomware", "critical"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "How long has this been going on? Our accounting team can't access any shared drives.",
+            "sentiment": "negative",
+            "tags": ["outage", "shared-drives", "accounting"],
+            "sender_type": "client_user",
+        },
+    ],
+    "maintenance-windows": [
+        {
+            "text": "Maintenance window scheduled: Saturday 11pm–3am CT. Server OS patches will be applied.",
+            "sentiment": "neutral",
+            "tags": ["maintenance", "patching", "windows"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Reminder: Firewall firmware upgrade tonight at 10pm. Expect 15–20 min of downtime.",
+            "sentiment": "neutral",
+            "tags": ["maintenance", "firewall", "upgrade"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Confirmed — we can approve the maintenance window for this Saturday. Proceed as planned.",
+            "sentiment": "positive",
+            "tags": ["maintenance", "approved"],
+            "sender_type": "client_user",
+        },
+        {
+            "text": "Can we reschedule the Saturday window to Sunday? We have a company event Saturday evening.",
+            "sentiment": "neutral",
+            "tags": ["maintenance", "reschedule"],
+            "sender_type": "client_user",
+        },
+        {
+            "text": "Maintenance complete. All patches applied successfully. No issues encountered.",
+            "sentiment": "positive",
+            "tags": ["maintenance", "complete", "patching"],
+            "sender_type": "msp_agent",
+        },
+    ],
+    "announcements": [
+        {
+            "text": "New security policy update: MFA is now required for all VPN connections effective next Monday.",
+            "sentiment": "neutral",
+            "tags": ["security", "mfa", "policy", "vpn"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Phishing alert: We've seen targeted phishing emails impersonating Microsoft support. Do not click links.",
+            "sentiment": "negative",
+            "tags": ["security", "phishing", "alert"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Reminder: End-of-life for Windows Server 2012 in 90 days. Please review upgrade roadmap shared last week.",
+            "sentiment": "neutral",
+            "tags": ["eol", "windows-server", "upgrade"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Great news — your backup health score improved to 98% this month. Keep up the good work!",
+            "sentiment": "positive",
+            "tags": ["backup", "health", "proactive"],
+            "sender_type": "msp_agent",
+        },
+    ],
+    "security-updates": [
+        {
+            "text": "Critical CVE patched across all endpoints: CVE-2025-1234. Reboot required for 4 workstations.",
+            "sentiment": "neutral",
+            "tags": ["cve", "patching", "endpoints", "security"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "AV definitions updated on all machines. No threats detected in latest scan.",
+            "sentiment": "positive",
+            "tags": ["antivirus", "scan", "clean"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "User account locked after repeated failed login attempts from unknown IP. Account reset completed.",
+            "sentiment": "negative",
+            "tags": ["account-lockout", "security", "brute-force"],
+            "sender_type": "msp_agent",
+        },
+        {
+            "text": "Quarterly penetration test scheduled for next month. We'll share the scope document shortly.",
+            "sentiment": "neutral",
+            "tags": ["pentest", "security", "quarterly"],
+            "sender_type": "msp_agent",
+        },
+    ],
+}
+
+
+def _random_timestamp(rng: random.Random, days_back: int = 90) -> str:
+    """Return a random ISO 8601 UTC timestamp within the last `days_back` days."""
+    now = datetime.now(timezone.utc)
+    delta = timedelta(seconds=rng.randint(0, days_back * 86400))
+    return (now - delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _pick_ticket_id(rng: random.Random) -> int:
+    return rng.randint(10000, 99999)
+
+
+def generate_messages_for_client(
+    client_id: int,
+    client_name: str,
+    rng: random.Random,
+    messages_per_client: int = 12,
+) -> list[SlackMessage]:
+    """Generate `messages_per_client` synthetic Slack messages for one HaloPSA client."""
+    client_users = _make_client_users(client_id, client_name)
+    messages: list[SlackMessage] = []
+
+    channel_pool = CHANNELS.copy()
+    rng.shuffle(channel_pool)
+
+    for i in range(messages_per_client):
+        channel = channel_pool[i % len(channel_pool)]
+        templates = _TEMPLATES[channel]
+        template = rng.choice(templates)
+
+        sender_type = template["sender_type"]
+        if sender_type == "msp_agent":
+            agent = rng.choice(MSP_AGENTS)
+            sender_id = agent["sender_id"]
+            sender_name = agent["sender_name"]
+        else:
+            user = rng.choice(client_users)
+            sender_id = user["sender_id"]
+            sender_name = user["sender_name"]
+
+        text = template["text"]
+        ticket_ref: int | None = None
+        if "{{TICKET}}" in text:
+            ticket_ref = _pick_ticket_id(rng)
+            text = text.replace("{{TICKET}}", str(ticket_ref))
+
+        ts = _random_timestamp(rng)
+        is_reply = rng.random() < 0.25
+        thread_ts = _random_timestamp(rng, days_back=1) if is_reply else None
+
+        messages.append(
+            SlackMessage(
+                message_id=str(uuid.uuid4()),
+                client_id=client_id,
+                client_name=client_name,
+                channel=channel,
+                sender_id=sender_id,
+                sender_name=sender_name,
+                sender_type=sender_type,
+                message_text=text,
+                timestamp=ts,
+                thread_ts=thread_ts,
+                is_reply=is_reply,
+                sentiment=template["sentiment"],
+                ticket_reference=ticket_ref,
+                tags=list(template["tags"]),
+            )
+        )
+
+    # Sort by timestamp ascending
+    messages.sort(key=lambda m: m.timestamp)
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Client source helpers
+# ---------------------------------------------------------------------------
+
+_CLIENT_PROFILES_PATH = os.path.join(os.path.dirname(__file__), "client_profiles.json")
+
+_FALLBACK_CLIENTS = [
+    {"id": 1, "name": "Acme Corporation"},
+    {"id": 2, "name": "Globex Industries"},
+    {"id": 3, "name": "Initech Solutions"},
+    {"id": 4, "name": "Umbrella Technologies"},
+    {"id": 5, "name": "Hooli Enterprises"},
+    {"id": 6, "name": "Pied Piper LLC"},
+    {"id": 7, "name": "Dunder Mifflin Paper"},
+    {"id": 8, "name": "Vandelay Industries"},
+]
+
+
+def _load_clients_from_profiles() -> list[dict]:
+    """
+    Read client IDs from client_profiles.json (keys are client IDs).
+    Returns list of {id, name} dicts. Falls back to empty list on any error.
+    """
+    if not os.path.exists(_CLIENT_PROFILES_PATH):
+        return []
+    try:
+        with open(_CLIENT_PROFILES_PATH, "r") as f:
+            profiles = json.load(f)
+        return [
+            {"id": int(k), "name": f"Client {k}"}
+            for k in profiles.keys()
+            if k.isdigit()
+        ]
+    except (json.JSONDecodeError, OSError, ValueError):
+        return []
+
+
+def get_clients(use_fallback_if_empty: bool = True) -> list[dict]:
+    """
+    Return list of {id, name} dicts representing HaloPSA accounts.
+    Loads from client_profiles.json when available; falls back to built-in
+    sample list if the file is empty or absent.
+    """
+    clients = _load_clients_from_profiles()
+    if not clients and use_fallback_if_empty:
+        clients = _FALLBACK_CLIENTS
+    return clients
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def populate(
+    reset: bool = False,
+    messages_per_client: int = 12,
+    seed: int = DEFAULT_SEED,
+) -> list[SlackMessage]:
+    """
+    Generate and persist synthetic Slack messages for all known HaloPSA clients.
+
+    Args:
+        reset: If True, clear all existing Slack data before generating.
+        messages_per_client: Number of messages to generate per client.
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        List of all generated SlackMessage objects.
+    """
+    rng = random.Random(seed)
+    clients = get_clients()
+
+    if reset:
+        save_slack_data([])
+        print("Existing Slack data cleared.")
+
+    all_generated: list[SlackMessage] = []
+
+    for client in clients:
+        client_id = client["id"]
+        client_name = client["name"]
+
+        if not reset:
+            # Remove existing records for this client to avoid duplicates
+            deleted = delete_messages_for_client(client_id)
+            if deleted:
+                print(f"  Removed {deleted} existing messages for client {client_id} ({client_name})")
+
+        msgs = generate_messages_for_client(client_id, client_name, rng, messages_per_client)
+
+        # Load current data, append, and save
+        existing = load_slack_data()
+        save_slack_data(existing + msgs)
+
+        all_generated.extend(msgs)
+        print(f"  Generated {len(msgs)} messages for client {client_id} ({client_name})")
+
+    total = len(all_generated)
+    print(f"\nDone. {total} Slack messages written to slack_data.json.")
+    return all_generated
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Populate slack_data.json with synthetic Slack messages.")
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Clear all existing Slack data before generating new records.",
+    )
+    parser.add_argument(
+        "--messages-per-client",
+        type=int,
+        default=12,
+        metavar="N",
+        help="Number of messages to generate per HaloPSA client (default: 12).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=f"Random seed for reproducibility (default: {DEFAULT_SEED}).",
+    )
+    args = parser.parse_args()
+
+    populate(
+        reset=args.reset,
+        messages_per_client=args.messages_per_client,
+        seed=args.seed,
+    )

--- a/populate_slack_data.py
+++ b/populate_slack_data.py
@@ -332,14 +332,15 @@ def generate_messages_for_client(
 _CLIENT_PROFILES_PATH = os.path.join(os.path.dirname(__file__), "client_profiles.json")
 
 _FALLBACK_CLIENTS = [
-    {"id": 1, "name": "Acme Corporation"},
-    {"id": 2, "name": "Globex Industries"},
-    {"id": 3, "name": "Initech Solutions"},
-    {"id": 4, "name": "Umbrella Technologies"},
-    {"id": 5, "name": "Hooli Enterprises"},
-    {"id": 6, "name": "Pied Piper LLC"},
-    {"id": 7, "name": "Dunder Mifflin Paper"},
-    {"id": 8, "name": "Vandelay Industries"},
+    {"id": 1, "name": "Acme Corp"},
+    {"id": 2, "name": "Acorn Construction"},
+    {"id": 3, "name": "Create"},
+    {"id": 4, "name": "Freston Cakes and Bakes"},
+    {"id": 5, "name": "Mario and Luigi's Pizza Place"},
+    {"id": 6, "name": "Ron's Iron works"},
+    {"id": 7, "name": "St Johns High School"},
+    {"id": 8, "name": "Terry's Chocolates"},
+    {"id": 9, "name": "Tony's Tyre Emporium"},
 ]
 
 

--- a/slack_schema.py
+++ b/slack_schema.py
@@ -1,0 +1,174 @@
+"""
+slack_schema.py
+JSON persistence layer for Slack message data tied to HaloPSA client accounts.
+Stored in slack_data.json (gitignored).
+
+Schema:
+  message_id      — UUID4 string, unique per message
+  client_id       — int, HaloPSA account ID
+  client_name     — str
+  channel         — str, Slack channel name (without #)
+  sender_id       — str, Slack user ID (e.g. "U01ABC123")
+  sender_name     — str
+  sender_type     — "client_user" | "msp_agent"
+  message_text    — str
+  timestamp       — ISO 8601 UTC datetime string
+  thread_ts       — str | None, parent message timestamp if this is a reply
+  is_reply        — bool
+  sentiment       — "positive" | "neutral" | "negative"
+  ticket_reference — int | None, HaloPSA ticket ID if referenced
+  tags            — list[str]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import uuid
+from dataclasses import asdict, dataclass, field
+
+_SLACK_DATA_PATH = os.path.join(os.path.dirname(__file__), "slack_data.json")
+
+VALID_SENDER_TYPES = {"client_user", "msp_agent"}
+VALID_SENTIMENTS = {"positive", "neutral", "negative"}
+
+
+@dataclass
+class SlackMessage:
+    client_id: int
+    client_name: str
+    channel: str
+    sender_id: str
+    sender_name: str
+    sender_type: str  # "client_user" | "msp_agent"
+    message_text: str
+    timestamp: str  # ISO 8601 UTC
+    message_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    thread_ts: str | None = None
+    is_reply: bool = False
+    sentiment: str = "neutral"  # "positive" | "neutral" | "negative"
+    ticket_reference: int | None = None
+    tags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SlackMessage":
+        return cls(
+            message_id=data.get("message_id", str(uuid.uuid4())),
+            client_id=data["client_id"],
+            client_name=data["client_name"],
+            channel=data["channel"],
+            sender_id=data["sender_id"],
+            sender_name=data["sender_name"],
+            sender_type=data["sender_type"],
+            message_text=data["message_text"],
+            timestamp=data["timestamp"],
+            thread_ts=data.get("thread_ts"),
+            is_reply=data.get("is_reply", False),
+            sentiment=data.get("sentiment", "neutral"),
+            ticket_reference=data.get("ticket_reference"),
+            tags=data.get("tags", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def load_slack_data() -> list[SlackMessage]:
+    """Read slack_data.json; return empty list if absent or corrupt."""
+    if not os.path.exists(_SLACK_DATA_PATH):
+        return []
+    try:
+        with open(_SLACK_DATA_PATH, "r") as f:
+            raw = json.load(f)
+        return [SlackMessage.from_dict(m) for m in raw.get("messages", [])]
+    except (json.JSONDecodeError, OSError, KeyError, TypeError):
+        return []
+
+
+def save_slack_data(messages: list[SlackMessage]) -> None:
+    """Write messages atomically via os.replace() on a temp file."""
+    dir_name = os.path.dirname(_SLACK_DATA_PATH) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump({"messages": [m.to_dict() for m in messages]}, f, indent=2)
+        os.replace(tmp_path, _SLACK_DATA_PATH)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# CRUD helpers
+# ---------------------------------------------------------------------------
+
+
+def add_message(message: SlackMessage) -> None:
+    """Append a new message. Raises ValueError if message_id already exists."""
+    messages = load_slack_data()
+    existing_ids = {m.message_id for m in messages}
+    if message.message_id in existing_ids:
+        raise ValueError(f"Message with id {message.message_id!r} already exists.")
+    messages.append(message)
+    save_slack_data(messages)
+
+
+def upsert_message(message: SlackMessage) -> None:
+    """Insert or replace a message by message_id."""
+    messages = load_slack_data()
+    idx = next((i for i, m in enumerate(messages) if m.message_id == message.message_id), None)
+    if idx is not None:
+        messages[idx] = message
+    else:
+        messages.append(message)
+    save_slack_data(messages)
+
+
+def get_message_by_id(message_id: str) -> SlackMessage | None:
+    """Return the message with the given ID, or None if not found."""
+    for m in load_slack_data():
+        if m.message_id == message_id:
+            return m
+    return None
+
+
+def get_messages_for_client(client_id: int) -> list[SlackMessage]:
+    """Return all messages associated with a HaloPSA client ID."""
+    return [m for m in load_slack_data() if m.client_id == client_id]
+
+
+def get_messages_by_channel(channel: str) -> list[SlackMessage]:
+    """Return all messages in a given channel (case-insensitive)."""
+    channel_lower = channel.lower()
+    return [m for m in load_slack_data() if m.channel.lower() == channel_lower]
+
+
+def get_messages_by_sentiment(sentiment: str) -> list[SlackMessage]:
+    """Return all messages with a given sentiment ('positive', 'neutral', 'negative')."""
+    return [m for m in load_slack_data() if m.sentiment == sentiment]
+
+
+def delete_message(message_id: str) -> bool:
+    """Remove a message by ID. Returns True if deleted, False if not found."""
+    messages = load_slack_data()
+    filtered = [m for m in messages if m.message_id != message_id]
+    if len(filtered) == len(messages):
+        return False
+    save_slack_data(filtered)
+    return True
+
+
+def delete_messages_for_client(client_id: int) -> int:
+    """Remove all messages for a client. Returns count of deleted messages."""
+    messages = load_slack_data()
+    kept = [m for m in messages if m.client_id != client_id]
+    deleted = len(messages) - len(kept)
+    save_slack_data(kept)
+    return deleted

--- a/tests/test_chat_engine.py
+++ b/tests/test_chat_engine.py
@@ -769,3 +769,90 @@ class TestMatchIndustry:
     def test_whitespace_stripped(self):
         result = match_industry("  finance  ")
         assert result == "Finance & Insurance"
+
+
+# ── Intent.SHOW_SLACK_MESSAGES ───────────────────────────────────────
+
+
+class TestParseIntentRegexShowSlackMessages:
+    def test_slack_messages(self):
+        intent, _ = parse_intent_regex("Show Slack messages for Acme")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_messages_variant(self):
+        intent, _ = parse_intent_regex("show me slack messages")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_for_client(self):
+        intent, _ = parse_intent_regex("slack for Terry's Chocolates")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_channel(self):
+        intent, _ = parse_intent_regex("slack channel incidents")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_activity(self):
+        intent, _ = parse_intent_regex("slack activity for Acme")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_incidents(self):
+        intent, _ = parse_intent_regex("slack incidents for Ron's Iron works")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_support(self):
+        intent, _ = parse_intent_regex("slack support messages")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_slack_alert(self):
+        intent, _ = parse_intent_regex("show slack alerts for Acme Corp")
+        assert intent == Intent.SHOW_SLACK_MESSAGES
+
+    def test_not_triggered_by_qbr(self):
+        intent, _ = parse_intent_regex("generate qbr for Acme")
+        assert intent != Intent.SHOW_SLACK_MESSAGES
+
+    def test_not_triggered_by_list_clients(self):
+        intent, _ = parse_intent_regex("list all clients")
+        assert intent != Intent.SHOW_SLACK_MESSAGES
+
+
+class TestShowSlackMessagesParamExtraction:
+    def test_extracts_client_name(self):
+        _, params = parse_intent_regex("Show Slack messages for Acme Corp")
+        assert params.get("client_name") == "Acme Corp"
+
+    def test_extracts_client_name_with_channel(self):
+        _, params = parse_intent_regex(
+            "Show Slack messages for Acme Corp in #incidents"
+        )
+        assert params.get("client_name") == "Acme Corp"
+
+    def test_extracts_channel_hash(self):
+        _, params = parse_intent_regex("Show Slack messages in #incidents for Acme")
+        assert params.get("channel") == "incidents"
+
+    def test_extracts_channel_keyword(self):
+        _, params = parse_intent_regex("Show incidents channel Slack messages")
+        assert params.get("channel") == "incidents"
+
+    def test_extracts_sentiment_negative(self):
+        _, params = parse_intent_regex("Show negative Slack messages for Acme")
+        assert params.get("sentiment") == "negative"
+
+    def test_extracts_sentiment_positive(self):
+        _, params = parse_intent_regex("Show positive Slack messages for Acme")
+        assert params.get("sentiment") == "positive"
+
+    def test_extracts_sentiment_neutral(self):
+        _, params = parse_intent_regex("Show neutral Slack messages")
+        assert params.get("sentiment") == "neutral"
+
+    def test_no_params_on_bare_message(self):
+        _, params = parse_intent_regex("Show Slack messages")
+        assert params.get("client_name") is None
+        assert params.get("channel") is None
+        assert params.get("sentiment") is None
+
+    def test_no_spurious_sentiment(self):
+        _, params = parse_intent_regex("Show Slack messages for Acme")
+        assert params.get("sentiment") is None

--- a/tests/test_slack_schema.py
+++ b/tests/test_slack_schema.py
@@ -1,0 +1,542 @@
+"""Unit tests for slack_schema.py and populate_slack_data.py"""
+
+import json
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+import slack_schema
+import populate_slack_data
+from slack_schema import SlackMessage
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_slack_data(tmp_path):
+    """Redirect _SLACK_DATA_PATH to a temp file for every test."""
+    tmp_file = str(tmp_path / "slack_data.json")
+    with patch.object(slack_schema, "_SLACK_DATA_PATH", tmp_file):
+        yield tmp_file
+
+
+@pytest.fixture()
+def sample_message():
+    return SlackMessage(
+        message_id="test-id-001",
+        client_id=42,
+        client_name="Acme Corporation",
+        channel="support-alerts",
+        sender_id="U0CLI001",
+        sender_name="Acme IT Lead",
+        sender_type="client_user",
+        message_text="Our email server is down.",
+        timestamp="2025-01-15T10:30:00Z",
+        sentiment="negative",
+        ticket_reference=12345,
+        tags=["email", "outage"],
+    )
+
+
+@pytest.fixture()
+def msp_message():
+    return SlackMessage(
+        message_id="test-id-002",
+        client_id=42,
+        client_name="Acme Corporation",
+        channel="support-alerts",
+        sender_id="U0MSP001",
+        sender_name="Alex Rivera",
+        sender_type="msp_agent",
+        message_text="Ticket #12345 resolved: Email server restored.",
+        timestamp="2025-01-15T11:00:00Z",
+        sentiment="positive",
+        ticket_reference=12345,
+        tags=["email", "resolved"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# SlackMessage dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSlackMessageDataclass:
+    def test_defaults_assigned(self):
+        msg = SlackMessage(
+            client_id=1,
+            client_name="Test Co",
+            channel="general",
+            sender_id="U001",
+            sender_name="Alice",
+            sender_type="msp_agent",
+            message_text="Hello",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        assert msg.is_reply is False
+        assert msg.sentiment == "neutral"
+        assert msg.ticket_reference is None
+        assert msg.tags == []
+        assert msg.thread_ts is None
+        assert len(msg.message_id) == 36  # UUID4 format
+
+    def test_message_id_unique_per_instance(self):
+        m1 = SlackMessage(1, "Co", "general", "U1", "Alice", "msp_agent", "Hi", "2025-01-01T00:00:00Z")
+        m2 = SlackMessage(1, "Co", "general", "U2", "Bob", "msp_agent", "Hi", "2025-01-01T00:00:00Z")
+        assert m1.message_id != m2.message_id
+
+    def test_to_dict_round_trip(self, sample_message):
+        d = sample_message.to_dict()
+        assert d["client_id"] == 42
+        assert d["channel"] == "support-alerts"
+        assert d["tags"] == ["email", "outage"]
+        assert d["ticket_reference"] == 12345
+
+    def test_from_dict_round_trip(self, sample_message):
+        d = sample_message.to_dict()
+        restored = SlackMessage.from_dict(d)
+        assert restored.message_id == sample_message.message_id
+        assert restored.client_id == sample_message.client_id
+        assert restored.sentiment == sample_message.sentiment
+        assert restored.tags == sample_message.tags
+
+    def test_from_dict_generates_id_if_missing(self):
+        d = {
+            "client_id": 1,
+            "client_name": "Co",
+            "channel": "general",
+            "sender_id": "U1",
+            "sender_name": "Alice",
+            "sender_type": "msp_agent",
+            "message_text": "Hi",
+            "timestamp": "2025-01-01T00:00:00Z",
+        }
+        msg = SlackMessage.from_dict(d)
+        assert len(msg.message_id) == 36
+
+
+# ---------------------------------------------------------------------------
+# Persistence: load_slack_data / save_slack_data
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSlackData:
+    def test_missing_file_returns_empty_list(self):
+        result = slack_schema.load_slack_data()
+        assert result == []
+
+    def test_loads_valid_messages(self, sample_message):
+        slack_schema.save_slack_data([sample_message])
+        loaded = slack_schema.load_slack_data()
+        assert len(loaded) == 1
+        assert loaded[0].message_id == sample_message.message_id
+
+    def test_corrupt_json_returns_empty_list(self, isolated_slack_data):
+        with open(isolated_slack_data, "w") as f:
+            f.write("not valid json {{{")
+        result = slack_schema.load_slack_data()
+        assert result == []
+
+    def test_missing_messages_key_returns_empty_list(self, isolated_slack_data):
+        with open(isolated_slack_data, "w") as f:
+            json.dump({}, f)
+        result = slack_schema.load_slack_data()
+        assert result == []
+
+
+class TestSaveSlackData:
+    def test_writes_multiple_messages(self, sample_message, msp_message):
+        slack_schema.save_slack_data([sample_message, msp_message])
+        loaded = slack_schema.load_slack_data()
+        assert len(loaded) == 2
+
+    def test_overwrites_existing_data(self, sample_message, msp_message):
+        slack_schema.save_slack_data([sample_message])
+        slack_schema.save_slack_data([msp_message])
+        loaded = slack_schema.load_slack_data()
+        assert len(loaded) == 1
+        assert loaded[0].message_id == msp_message.message_id
+
+    def test_empty_list_clears_all(self, sample_message):
+        slack_schema.save_slack_data([sample_message])
+        slack_schema.save_slack_data([])
+        assert slack_schema.load_slack_data() == []
+
+
+# ---------------------------------------------------------------------------
+# CRUD: add_message
+# ---------------------------------------------------------------------------
+
+
+class TestAddMessage:
+    def test_adds_new_message(self, sample_message):
+        slack_schema.add_message(sample_message)
+        result = slack_schema.load_slack_data()
+        assert len(result) == 1
+        assert result[0].message_id == sample_message.message_id
+
+    def test_raises_on_duplicate_id(self, sample_message):
+        slack_schema.add_message(sample_message)
+        with pytest.raises(ValueError, match="already exists"):
+            slack_schema.add_message(sample_message)
+
+    def test_adds_multiple_distinct_messages(self, sample_message, msp_message):
+        slack_schema.add_message(sample_message)
+        slack_schema.add_message(msp_message)
+        assert len(slack_schema.load_slack_data()) == 2
+
+
+# ---------------------------------------------------------------------------
+# CRUD: upsert_message
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertMessage:
+    def test_inserts_new_message(self, sample_message):
+        slack_schema.upsert_message(sample_message)
+        assert len(slack_schema.load_slack_data()) == 1
+
+    def test_replaces_existing_message(self, sample_message):
+        slack_schema.upsert_message(sample_message)
+        updated = SlackMessage.from_dict({
+            **sample_message.to_dict(),
+            "message_text": "Updated text",
+            "sentiment": "positive",
+        })
+        slack_schema.upsert_message(updated)
+        loaded = slack_schema.load_slack_data()
+        assert len(loaded) == 1
+        assert loaded[0].message_text == "Updated text"
+        assert loaded[0].sentiment == "positive"
+
+    def test_preserves_other_messages(self, sample_message, msp_message):
+        slack_schema.upsert_message(sample_message)
+        slack_schema.upsert_message(msp_message)
+        updated = SlackMessage.from_dict({**sample_message.to_dict(), "sentiment": "neutral"})
+        slack_schema.upsert_message(updated)
+        loaded = slack_schema.load_slack_data()
+        assert len(loaded) == 2
+
+
+# ---------------------------------------------------------------------------
+# CRUD: get_message_by_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessageById:
+    def test_returns_correct_message(self, sample_message):
+        slack_schema.add_message(sample_message)
+        result = slack_schema.get_message_by_id(sample_message.message_id)
+        assert result is not None
+        assert result.message_id == sample_message.message_id
+
+    def test_returns_none_for_unknown_id(self):
+        result = slack_schema.get_message_by_id("nonexistent-id")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# CRUD: get_messages_for_client
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesForClient:
+    def test_returns_messages_for_client(self, sample_message, msp_message):
+        other = SlackMessage(
+            client_id=99,
+            client_name="Other Co",
+            channel="general",
+            sender_id="U999",
+            sender_name="Other",
+            sender_type="client_user",
+            message_text="Hi",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        slack_schema.save_slack_data([sample_message, msp_message, other])
+        result = slack_schema.get_messages_for_client(42)
+        assert len(result) == 2
+        assert all(m.client_id == 42 for m in result)
+
+    def test_returns_empty_for_unknown_client(self, sample_message):
+        slack_schema.add_message(sample_message)
+        result = slack_schema.get_messages_for_client(999)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# CRUD: get_messages_by_channel
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesByChannel:
+    def test_returns_matching_channel(self, sample_message, msp_message):
+        other = SlackMessage(
+            client_id=1,
+            client_name="Co",
+            channel="general",
+            sender_id="U1",
+            sender_name="A",
+            sender_type="msp_agent",
+            message_text="Hi",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        slack_schema.save_slack_data([sample_message, msp_message, other])
+        result = slack_schema.get_messages_by_channel("support-alerts")
+        assert len(result) == 2
+
+    def test_case_insensitive_match(self, sample_message):
+        slack_schema.add_message(sample_message)
+        result = slack_schema.get_messages_by_channel("SUPPORT-ALERTS")
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# CRUD: get_messages_by_sentiment
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesBySentiment:
+    def test_filters_by_sentiment(self, sample_message, msp_message):
+        # sample_message = negative, msp_message = positive
+        slack_schema.save_slack_data([sample_message, msp_message])
+        neg = slack_schema.get_messages_by_sentiment("negative")
+        pos = slack_schema.get_messages_by_sentiment("positive")
+        assert len(neg) == 1
+        assert len(pos) == 1
+        assert neg[0].message_id == sample_message.message_id
+
+    def test_returns_empty_for_unmatched_sentiment(self, sample_message):
+        slack_schema.add_message(sample_message)
+        result = slack_schema.get_messages_by_sentiment("positive")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# CRUD: delete_message
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMessage:
+    def test_deletes_existing_message(self, sample_message):
+        slack_schema.add_message(sample_message)
+        deleted = slack_schema.delete_message(sample_message.message_id)
+        assert deleted is True
+        assert slack_schema.load_slack_data() == []
+
+    def test_returns_false_for_nonexistent(self):
+        result = slack_schema.delete_message("fake-id")
+        assert result is False
+
+    def test_preserves_other_messages(self, sample_message, msp_message):
+        slack_schema.save_slack_data([sample_message, msp_message])
+        slack_schema.delete_message(sample_message.message_id)
+        remaining = slack_schema.load_slack_data()
+        assert len(remaining) == 1
+        assert remaining[0].message_id == msp_message.message_id
+
+
+# ---------------------------------------------------------------------------
+# CRUD: delete_messages_for_client
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMessagesForClient:
+    def test_deletes_all_client_messages(self, sample_message, msp_message):
+        slack_schema.save_slack_data([sample_message, msp_message])
+        count = slack_schema.delete_messages_for_client(42)
+        assert count == 2
+        assert slack_schema.load_slack_data() == []
+
+    def test_returns_zero_for_unknown_client(self, sample_message):
+        slack_schema.add_message(sample_message)
+        count = slack_schema.delete_messages_for_client(999)
+        assert count == 0
+        assert len(slack_schema.load_slack_data()) == 1
+
+    def test_preserves_other_client_messages(self, sample_message):
+        other = SlackMessage(
+            client_id=7,
+            client_name="Other",
+            channel="general",
+            sender_id="U7",
+            sender_name="User",
+            sender_type="client_user",
+            message_text="Hi",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        slack_schema.save_slack_data([sample_message, other])
+        slack_schema.delete_messages_for_client(42)
+        remaining = slack_schema.load_slack_data()
+        assert len(remaining) == 1
+        assert remaining[0].client_id == 7
+
+
+# ---------------------------------------------------------------------------
+# populate_slack_data: generate_messages_for_client
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMessagesForClient:
+    def test_generates_correct_count(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme Corp", rng, 10)
+        assert len(msgs) == 10
+
+    def test_all_messages_linked_to_client(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(5, "Globex", rng, 8)
+        assert all(m.client_id == 5 for m in msgs)
+        assert all(m.client_name == "Globex" for m in msgs)
+
+    def test_messages_sorted_by_timestamp(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme", rng, 15)
+        timestamps = [m.timestamp for m in msgs]
+        assert timestamps == sorted(timestamps)
+
+    def test_sender_type_valid(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme", rng, 20)
+        assert all(m.sender_type in slack_schema.VALID_SENDER_TYPES for m in msgs)
+
+    def test_sentiment_valid(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme", rng, 20)
+        assert all(m.sentiment in slack_schema.VALID_SENTIMENTS for m in msgs)
+
+    def test_channels_from_valid_set(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme", rng, 20)
+        assert all(m.channel in populate_slack_data.CHANNELS for m in msgs)
+
+    def test_ticket_reference_matches_text(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme", rng, 50)
+        for m in msgs:
+            if m.ticket_reference is not None:
+                assert str(m.ticket_reference) in m.message_text
+
+    def test_no_template_placeholder_remaining(self):
+        import random
+        rng = random.Random(42)
+        msgs = populate_slack_data.generate_messages_for_client(1, "Acme", rng, 50)
+        for m in msgs:
+            assert "{{TICKET}}" not in m.message_text
+
+
+# ---------------------------------------------------------------------------
+# populate_slack_data: populate()
+# ---------------------------------------------------------------------------
+
+
+class TestPopulate:
+    @pytest.fixture(autouse=True)
+    def patch_slack_path(self, isolated_slack_data):
+        """Also patch the populate module's reference to the data file."""
+        with patch.object(slack_schema, "_SLACK_DATA_PATH", isolated_slack_data):
+            yield
+
+    def test_populate_writes_messages(self):
+        clients = [
+            {"id": 1, "name": "Acme"},
+            {"id": 2, "name": "Globex"},
+        ]
+        with patch.object(populate_slack_data, "get_clients", return_value=clients):
+            result = populate_slack_data.populate(messages_per_client=5, seed=99)
+        assert len(result) == 10  # 2 clients * 5 messages
+
+    def test_populate_reset_clears_existing(self, sample_message):
+        slack_schema.add_message(sample_message)
+        clients = [{"id": 1, "name": "NewCo"}]
+        with patch.object(populate_slack_data, "get_clients", return_value=clients):
+            populate_slack_data.populate(reset=True, messages_per_client=3, seed=1)
+        all_msgs = slack_schema.load_slack_data()
+        # After reset, only newly generated messages for client 1 should exist
+        assert all(m.client_id == 1 for m in all_msgs)
+        assert len(all_msgs) == 3
+
+    def test_populate_idempotent_with_reset(self):
+        clients = [{"id": 10, "name": "Initech"}]
+        with patch.object(populate_slack_data, "get_clients", return_value=clients):
+            populate_slack_data.populate(reset=True, messages_per_client=4, seed=7)
+            populate_slack_data.populate(reset=True, messages_per_client=4, seed=7)
+        all_msgs = slack_schema.load_slack_data()
+        assert len(all_msgs) == 4
+
+    def test_populate_without_reset_replaces_client_data(self, sample_message):
+        # sample_message is for client 42
+        slack_schema.add_message(sample_message)
+        clients = [{"id": 42, "name": "Acme Corporation"}]
+        with patch.object(populate_slack_data, "get_clients", return_value=clients):
+            populate_slack_data.populate(reset=False, messages_per_client=3, seed=5)
+        all_msgs = slack_schema.load_slack_data()
+        # Old message replaced; 3 new ones
+        assert len(all_msgs) == 3
+
+    def test_populate_uses_fallback_clients_when_no_profiles(self):
+        with patch.object(populate_slack_data, "_CLIENT_PROFILES_PATH", "/nonexistent/path.json"):
+            clients = populate_slack_data.get_clients(use_fallback_if_empty=True)
+        assert len(clients) > 0
+        assert clients == populate_slack_data._FALLBACK_CLIENTS
+
+    def test_populate_reproducible_with_same_seed(self):
+        clients = [{"id": 1, "name": "Acme"}]
+        with patch.object(populate_slack_data, "get_clients", return_value=clients):
+            r1 = populate_slack_data.populate(reset=True, messages_per_client=5, seed=42)
+        slack_schema.save_slack_data([])
+        with patch.object(populate_slack_data, "get_clients", return_value=clients):
+            r2 = populate_slack_data.populate(reset=True, messages_per_client=5, seed=42)
+        texts1 = [m.message_text for m in r1]
+        texts2 = [m.message_text for m in r2]
+        assert texts1 == texts2
+
+
+# ---------------------------------------------------------------------------
+# populate_slack_data: get_clients
+# ---------------------------------------------------------------------------
+
+
+class TestGetClients:
+    def test_returns_fallback_when_no_profile_file(self, tmp_path):
+        fake_path = str(tmp_path / "nonexistent.json")
+        with patch.object(populate_slack_data, "_CLIENT_PROFILES_PATH", fake_path):
+            clients = populate_slack_data.get_clients()
+        assert clients == populate_slack_data._FALLBACK_CLIENTS
+
+    def test_loads_from_profiles_when_available(self, tmp_path):
+        profiles = {"1": {"employee_count": 50, "avg_hourly_rate": 60}, "2": {}}
+        path = str(tmp_path / "client_profiles.json")
+        with open(path, "w") as f:
+            json.dump(profiles, f)
+        with patch.object(populate_slack_data, "_CLIENT_PROFILES_PATH", path):
+            clients = populate_slack_data.get_clients()
+        ids = {c["id"] for c in clients}
+        assert ids == {1, 2}
+
+    def test_corrupt_profiles_returns_fallback(self, tmp_path):
+        path = str(tmp_path / "client_profiles.json")
+        with open(path, "w") as f:
+            f.write("{{invalid json")
+        with patch.object(populate_slack_data, "_CLIENT_PROFILES_PATH", path):
+            clients = populate_slack_data.get_clients()
+        assert clients == populate_slack_data._FALLBACK_CLIENTS
+
+    def test_empty_profiles_returns_fallback(self, tmp_path):
+        path = str(tmp_path / "client_profiles.json")
+        with open(path, "w") as f:
+            json.dump({}, f)
+        with patch.object(populate_slack_data, "_CLIENT_PROFILES_PATH", path):
+            clients = populate_slack_data.get_clients(use_fallback_if_empty=True)
+        assert clients == populate_slack_data._FALLBACK_CLIENTS


### PR DESCRIPTION
Adds a JSON-backed persistence layer for Slack messages tied to HaloPSA client accounts, plus a standalone script to populate it with realistic synthetic MSP/client Slack data.

Closes #15

Generated with [Claude Code](https://claude.ai/code)